### PR TITLE
typo: `appendicies` -> `methodology`

### DIFF
--- a/exercises/3.0-branching-ex.md
+++ b/exercises/3.0-branching-ex.md
@@ -5,7 +5,7 @@ checkout to it
 * check out a previous commit on that branch. We discussed `detached HEAD`
 state before. What does it look like? Try `git log` and `git status` in this
 state. Discuss with your partner the different ways you'd go back to the most
-recent commit of the appendices branch. Try them out. use `git status` and `git
+recent commit of the `methodology` branch. Try them out. use `git status` and `git
 log` to help you.
 * After this, `git checkout methodology`
 * Edit the metholology.md file. Try to write a bit about how python is going to be used for the work that you do, and what python packages are going to be used to make that happen. Add it to staging and commit it.


### PR DESCRIPTION
I think this is fixes a typo introduced when the branch name was changed around commit
d4a76b620b0f54bc12cae7025dfdddee99221074